### PR TITLE
Implement new API update of Correios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Correios Brasil -- VERSÃO 3.0.2
+# Correios Brasil -- VERSÃO 3.0.3
 
 <h4  align="center">
 
@@ -367,8 +367,8 @@ Copyright (c) 2020 Lucas Finoti
 
 ## 💪 Contribuidores
 
-| [<img src="https://avatars0.githubusercontent.com/u/42827195?v=3&s=115" width="115"><br><sub>@jonabf1</sub>](https://github.com/jonabf1) | [<img src="https://avatars0.githubusercontent.com/u/18602545?v=3&s=115" width="115"><br><sub>@francopan</sub>](https://github.com/francopan) |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [<img src="https://avatars0.githubusercontent.com/u/42827195?v=3&s=115" width="115"><br><sub>@jonabf1</sub>](https://github.com/jonabf1) | [<img src="https://avatars0.githubusercontent.com/u/18602545?v=3&s=115" width="115"><br><sub>@francopan</sub>](https://github.com/francopan) | [<img src="https://avatars0.githubusercontent.com/u/3102127?v=3&s=115" width="115"><br><sub>@ivanseidel</sub>](https://github.com/ivanseidel) |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## 🚀 Autor
 

--- a/lib/features/rastreio.ts
+++ b/lib/features/rastreio.ts
@@ -1,6 +1,14 @@
 import { request } from '../utils/request';
 import URL from '../utils/URL';
 
+// Token Constante da requisição de PROXYAPP_RASTREAR
+const REQUEST_TOKEN = 'YW5kcm9pZDtici5jb20uY29ycmVpb3MucHJlYXRlbmRpbWVudG87RjMyRTI5OTc2NzA5MzU5ODU5RTBCOTdGNkY4QTQ4M0I5Qjk1MzU3OA=='
+
+// Guarda o token em cache e a data de expiração
+let tokenValue: string = null;
+let tokenExpiration: number = 0;
+let tokenPromise: Promise<string> = null;
+
 function rastrearEncomendas(codes: Array<string>): Promise<any> {
   /**
    * @param {Array[String]} codes
@@ -13,25 +21,84 @@ function rastrearEncomendas(codes: Array<string>): Promise<any> {
   return response;
 }
 
+function gerarTokenApp(): Promise<string> {
+  /**
+   * Função responsável por gerar um token para realizar a consulta de encomendas caso o token não esteja em cache
+   */
+
+  // Checa se o token está em cache e se não está expirado
+  if (tokenValue && tokenExpiration > Date.now()) {
+    return Promise.resolve(tokenValue);
+  }
+
+  // Checa se já existe uma promise de token em andamento
+  if (tokenPromise) {
+    return tokenPromise;
+  }
+
+  // Cria uma nova promise de token
+  tokenPromise = new Promise((resolve, reject) => {
+    request(URL.PROXYAPP_TOKEN, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': 'Dart/2.18 (dart:io)',
+      },
+      data: {
+        requestToken: REQUEST_TOKEN
+      }
+    })
+    .then((body: any) => {
+      tokenPromise = null;
+      const jwt = body.data.token;
+      // Parseia o JWT para pegar a data de expiração (iat)
+      const jwtData = jwt.split('.')[1];
+      const jwtBuffer = Buffer.from(jwtData, 'base64');
+      const jwtString = jwtBuffer.toString('ascii');
+      const jwtObject = JSON.parse(jwtString);
+      // Guarda o token em cache e a data de expiração
+      tokenValue = jwt;
+      tokenExpiration = jwtObject.exp * 1000 - 120000; // 120 segundos de margem
+      resolve(jwt);
+    })
+    .catch((err: any) => {
+      tokenValue = null;
+      tokenExpiration = 0;
+      tokenPromise = null;
+      reject(new Error('Falha ao autenticar requisição'))
+    })
+  });
+
+  return tokenPromise;
+}
+
 function fetchTrackingService(code: string): Promise<any> {
   /**
    * @param {string} code
    */
-
-  return new Promise((resolve, reject) =>
-    request(`${URL.PROXYAPP}/${code}`, {
-      method: 'GET',
-      headers: {
-        'content-type': 'application/json',
-      },
-    })
-      .then((body: any) => {
-        return resolve(body.data.objetos[0]);
+  return new Promise((resolve, reject) => {
+    // Gera um token para realizar a consulta
+    gerarTokenApp()
+      .then((token: string) => {
+        // Realiza a consulta
+        request(`${URL.PROXYAPP_RASTREAR}/${code}`, {
+          method: 'GET',
+          headers: {
+            'content-type': 'application/json',
+            'user-agent': 'Dart/2.18 (dart:io)',
+            'app-check-token': token,
+          },
+        })
+        .then((body: any) => {
+          // Retorna o resultado da consulta
+          return resolve(body.data.objetos[0]);
+        })
+        .catch((error: any) => {
+          reject(error);
+        })
       })
-      .catch((error: any) => {
-        reject(error);
-      }),
-  );
+      .catch(reject)
+  })
 }
 
 export default rastrearEncomendas;

--- a/lib/utils/URL.ts
+++ b/lib/utils/URL.ts
@@ -3,7 +3,8 @@ enum URL {
   BASECORREIOS = 'http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx',
   BASERASTREIO = 'https://www.linkcorreios.com.br',
   WIDENET = 'https://cep.widenet.host/busca-cep/api/cep',
-  PROXYAPP = 'https://proxyapp.correios.com.br/v1/sro-rastro',
+  PROXYAPP_RASTREAR = 'https://proxyapp.correios.com.br/v1/sro-rastro',
+  PROXYAPP_TOKEN = 'https://proxyapp.correios.com.br/v1/app-validation',
 }
 
 export default URL;

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 interface RequestOptions {
   method: 'GET' | 'POST';
   mode?: string;
+  data?: any;
   headers: any;
   timeout?: number | 0;
   agent?: http.Agent | https.Agent;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "correios-brasil",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Módulo completo consultar informações sobre o CEP, calcular o preço e os prazos das entregas das encomendas e também realizar o seu rastreio",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { sanitization } from '../lib/utils/validation';
+import { rastrearEncomendas } from '../lib';
+
 import {
   convertArrayBufferToString,
   convertXMLStringToJson,
@@ -63,4 +65,17 @@ describe('Parsers', () => {
       return buf;
     }
   });*/
+});
+
+describe('Rastreio de Pacotes', function () {
+  // Timeout to 10s
+  this.timeout(10000);
+  it('Chama API de rastreio e retorna erros pré-definidos', async () => {
+    let response = await rastrearEncomendas(['BR123456789BR', 'AAAA']);
+    expect(response[0].mensagem).to.be.equals('SRO-020: Objeto não encontrado na base de dados dos Correios.');
+    expect(response[0].codObjeto).to.be.equals('BR123456789BR');
+
+    expect(response[1].mensagem).to.be.equals('SRO-019: Objeto inválido');
+    expect(response[1].codObjeto).to.be.equals('AAAA');
+  });
 });


### PR DESCRIPTION
Implementado novo método para autenticar requisições antes de realizar a chamada de rastreio. (SEM breaking changes na api atual)

A implementação já cuida de:
- Evitar race-condition de gerar vários tokens (caso seja chamado com array o método de rastreio)
- Aproveitar tokens enquanto não expiraram (já considerando uma margem de segurança de 2 minutos)

Também criei um testezinho pra ser mais fácil rodar localmente (ele roda com pacotes que não existem, apenas pra certificar de que a api está sendo chamada corretamente e retornando em um formato válido).

Fixes #41.
Fixes #42.