### PR TITLE
fix/calcular-preco-prazo-return-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Correios Brasil -- VERSÃO 3.0.3
+# Correios Brasil -- VERSÃO 3.0.4
 
 <h4  align="center">
 

--- a/lib/features/precos.ts
+++ b/lib/features/precos.ts
@@ -8,12 +8,11 @@ import {
 import {
   PrecoPrazoRequest,
   PrecoPrazoResponse,
-  PrecoPrazoEvent,
 } from '../interfaces';
 
 function calcularPrecoPrazo(
   precoPrazo: PrecoPrazoRequest,
-): Promise<PrecoPrazoResponse> {
+): Promise<PrecoPrazoResponse[]> {
   /**
    * @param {Object} precoPrazo
    * Função responsável por realizar a consulta dos valores de entrega das
@@ -73,11 +72,11 @@ function fetchPrecoPrazo(p: PrecoPrazoRequest, code: string) {
   });
 }
 
-function convertJsonToPrazoPrecoResponse(obj: any): PrecoPrazoEvent {
+function convertJsonToPrazoPrecoResponse(obj: any): PrecoPrazoResponse {
   const precoPrazoResponse = Object.keys(obj).reduce((acc: any, key) => {
     acc[key] = obj[key]._text ? obj[key]._text : obj[key]._cdata;
     return acc;
-  }, {} as PrecoPrazoEvent);
+  }, {} as PrecoPrazoResponse);
   return precoPrazoResponse;
 }
 

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -27,24 +27,7 @@ export interface PrecoPrazoRequest {
   sCdAvisoRecebimento?: string;
   nIndicaCalculo?: string | number;
 }
-
-export interface PrecoPrazoEvent {
-  Codigo: string;
-  Valor: string;
-  PrazoEntrega: string;
-  ValorSemAdicionais: string;
-  ValorMaoPropria: string;
-  ValorAvisoRecebimento: string;
-  ValorDeclarado: string;
-  EntregaDomiciliar: string;
-  EntregaSabado: string;
-  obsFim: string;
-  Erro: string;
-  MsgErro: string;
-}
-
 export interface PrecoPrazoResponse {
-  [name: string]: {
     Codigo: string;
     Valor: string;
     PrazoEntrega: string;
@@ -57,7 +40,6 @@ export interface PrecoPrazoResponse {
     obsFim: string;
     Erro: string;
     MsgErro: string;
-  };
 }
 
 export interface RastreioEvent {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "correios-brasil",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Módulo completo consultar informações sobre o CEP, calcular o preço e os prazos das entregas das encomendas e também realizar o seu rastreio",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
Implementa a correção da tipagem do retorno da função `calcularPrecoPrazo`. Atualmente, ela possui o seguinte tipo:
`calcularPrecoPrazo(precoPrazo: PrecoPrazoRequest): Promise<PrecoPrazoResponse>`

No entanto, a interface `PrecoPrazoResponse` é de um objeto com vários possíveis objetos, com chave (string) e valor do tipo `PrecoPrazoEvent`, sendo que, na verdade, após a Promise ser resolvida, o retorno é um array de objetos do tipo `PrecoPrazoEvent`.

Interface `PrecoPrazoResponse` atual:
```
interface PrecoPrazoResponse {
  [name: string]: {
    Codigo: string;
    Valor: string;
    PrazoEntrega: string;
    ValorSemAdicionais: string;
    ValorMaoPropria: string;
    ValorAvisoRecebimento: string;
    ValorDeclarado: string;
    EntregaDomiciliar: string;
    EntregaSabado: string;
    obsFim: string;
    Erro: string;
    MsgErro: string;
  };
}
```

Interface `PrecoPrazoEvent` atual:

```
interface PrecoPrazoEvent {
  Codigo: string;
  Valor: string;
  PrazoEntrega: string;
  ValorSemAdicionais: string;
  ValorMaoPropria: string;
  ValorAvisoRecebimento: string;
  ValorDeclarado: string;
  EntregaDomiciliar: string;
  EntregaSabado: string;
  obsFim: string;
  Erro: string;
  MsgErro: string;
}
```

Exemplo de retorno dos dados atualmente:

```
[
  {
    Codigo: '04014',
    Valor: '35,10',
    PrazoEntrega: '1',
    ValorSemAdicionais: '35,10',
    ValorMaoPropria: '0,00',
    ValorAvisoRecebimento: '0,00',
    ValorValorDeclarado: '0,00',
    EntregaDomiciliar: 'S',
    EntregaSabado: 'S',
    obsFim: undefined,
    Erro: '0',
    MsgErro: undefined
  },
  {
    Codigo: '04510',
    Valor: '24,80',
    PrazoEntrega: '5',
    ValorSemAdicionais: '24,80',
    ValorMaoPropria: '0,00',
    ValorAvisoRecebimento: '0,00',
    ValorValorDeclarado: '0,00',
    EntregaDomiciliar: 'S',
    EntregaSabado: 'N',
    obsFim: undefined,
    Erro: '0',
    MsgErro: undefined
  }
]
```

Com as modificações, as interfaces de `PrecoPrazoResponse` e `PrecoPrazoEvent` ficaram idênticas, então mantive só a primeira e removi a segunda. Sendo assim, o retorno da função passou a ser do tipo `PrecoPrazoResponse[]`, com `PrecoPrazoResponse` sendo igual ao antigo `PrecoPrazoEvent`